### PR TITLE
chore: bump Scala 3 LTS to 3.3.8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ ThisBuild / scalacOptions ++= Seq("-release", "11")
 fork := true
 
 val scala213                = "2.13.13"
-val scala3                  = "3.3.3"
+val scala3                  = "3.3.8"
 val playVersion             = "3.0.11"
 val playWsStandaloneVersion = "3.0.10"
 


### PR DESCRIPTION
Bumps the Scala 3 LTS from `3.3.3` to `3.3.8` (latest LTS, released 2026-06-10).

3.3.8 backports bugfixes from the Scala Next series to the LTS line and is verified binary- and source-compatible against 1500+ projects in the Scala 3 Open Community Build, so this is a low-risk patch bump.

## Changes
- `build.sbt`: `scala3` `3.3.3` → `3.3.8`

(2.13.13 is unchanged; only the Scala 3 cross-version moves.)

## Verification
- `sbt +compile +test` — both 2.13.13 and 3.3.8 compile; all 38 tests pass on 3.3.8.

CI (`scripts/validate-code check` + `sbt +compile +test`) will confirm on this PR.