### PR TITLE
docs: update README dependency example to 3.0.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ At the moment only Play 3.x is supported
 ### play-mockws
 
 ```scala
-libraryDependencies += "io.github.hiveteq.play" %% "play-mockws-standalone" % "3.0.10" % Test
+libraryDependencies += "io.github.hiveteq.play" %% "play-mockws-standalone" % "3.0.11" % Test
 ```
 
 ## Usage


### PR DESCRIPTION
Updates the dependency snippet in the README to the latest release `3.0.11` (the release cut from #193, which bumped the Scala 3 LTS to 3.3.8).

- `README.md`: `3.0.10` → `3.0.11` in the `libraryDependencies` example

The version badge auto-resolves from Maven metadata and the Scala-versions table uses generic `3.3`, so neither needs editing.