### PR TITLE
chore: bump play-ws-standalone to 3.0.13 + track shared version vars in Renovate

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ fork := true
 val scala213                = "2.13.13"
 val scala3                  = "3.3.8"
 val playVersion             = "3.0.11"
-val playWsStandaloneVersion = "3.0.10"
+val playWsStandaloneVersion = "3.0.13"
 
 val testDependencies: Seq[ModuleID] = Seq(
   "org.scalatest"     %% "scalatest"       % "3.2.20",

--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,23 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^build\\.sbt$/"],
+      "matchStrings": [
+        "val playWsStandaloneVersion\\s*=\\s*\"(?<currentValue>.*?)\""
+      ],
+      "depNameTemplate": "org.playframework:play-ws-standalone",
+      "datasourceTemplate": "sbt"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^build\\.sbt$/"],
+      "matchStrings": [
+        "val playVersion\\s*=\\s*\"(?<currentValue>.*?)\""
+      ],
+      "depNameTemplate": "org.playframework:play-test",
+      "datasourceTemplate": "sbt"
+    }
+  ]
 }


### PR DESCRIPTION
## What

- Bump `playWsStandaloneVersion` 3.0.10 → 3.0.13 (latest stable 3.0.x).
- Add Renovate `customManagers` so both `playWsStandaloneVersion` and `playVersion` are tracked automatically.

## Why the bot missed it

Renovate is healthy (it bumps sbt, Scala, and even `play-test` via `playVersion`). But it never touched `playWsStandaloneVersion`: its sbt manager doesn't update a single version `val` that's **shared across multiple `libraryDependencies` entries** — here `play-ahc-ws-standalone`, `play-ws-standalone-json`, and `play-ws-standalone-xml` all reference the one var. As a result the ws version was always bumped by hand ("Upgrade Play ws version" commits).

The two `customManager` regexes pin each `val` to the artifact it drives, via the Scala-aware `sbt` datasource (no hardcoded `_2.13` suffix). Default `ignoreUnstable` keeps it on stable 3.0.x and off the `3.1.0-M*` milestones.

## Test

`sbt +compile +test` — all 38 tests pass on both Scala 2.13 and 3.3.