### PR TITLE
fix(ci): make validate-code work with the sbt 2.x launcher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,4 +34,6 @@ jobs:
         run: scripts/validate-code check
 
       - name: Test project
-        run: sbt +compile +test
+        # The sbt 2.x launcher joins arguments into one command line, which needs
+        # explicit ';' separators between commands.
+        run: sbt ";+compile ;+test"

--- a/scripts/validate-code
+++ b/scripts/validate-code
@@ -12,8 +12,18 @@ printMessage() {
   echo "[info]"
 }
 
+# The sbt 2.x launcher joins its CLI arguments into a single command line, and
+# `set` consumes to end of line -- so passing commands as separate arguments made
+# them parse as infix calls on the setting ("value scalafmtCheckAll is not a
+# member of sbt.Tags.Rule"). Build one explicitly ';'-delimited command line
+# instead, which both the 1.x and 2.x launchers parse the same way.
 runSbt() {
-  sbt 'set Global / concurrentRestrictions += Tags.limitAll(1)' "$@" | grep --line-buffered -v 'Resolving \|Generating '
+  local commands=""
+  local cmd
+  for cmd in "$@"; do
+    commands="$commands ;$cmd"
+  done
+  sbt ";set Global / concurrentRestrictions += Tags.limitAll(1)$commands" | grep --line-buffered -v 'Resolving \|Generating '
 }
 
 # Runs code formating validation in the current directory


### PR DESCRIPTION
## Symptom

Every open PR fails `Build and Test` with:

```
[error] ERROR: Scalafmt test failed for  source.
```

Nothing is actually misformatted — the lint command never ran.

## Root cause

`sbt/setup-sbt@v1` is **unpinned** and rolled from the sbt 1.x launcher to the 2.x one:

| Run | `SBT_RUNNER_VERSION` | Result |
|---|---|---|
| #195 | 1.12.12 | pass |
| #196 | 2.0.3 | fail |

The 2.x launcher joins its CLI arguments into a single command line, and sbt's `set` consumes to end of line. So `sbt 'set ...' scalafmtCheckAll scalafmtSbtCheck` parsed as:

```
Global / concurrentRestrictions += Tags.limitAll(1) scalafmtCheckAll scalafmtSbtCheck
                                                    ^^^^^^^^^^^^^^^^
value scalafmtCheckAll is not a member of sbt.Tags.Rule   [E008]
```

This is unrelated to any PR's contents — #196 and #199 only touch `renovatebot.yml`, which the build never reads, and all four branches are rebased onto current master.

Note master itself is **not** failing: `ci.yml` triggers only on `pull_request`/`workflow_call`, so CI never runs on master.

## Fix

Build one explicitly `;`-delimited command line, which the 1.x and 2.x launchers parse identically.

## Test

Verified locally (sbt 1.11.7 launcher):

- clean tree → exit 0
- injected a formatting violation → exit 1, `scalafmt: 1 files must be formatted`

The negative test matters: it proves the check actually executes rather than silently passing. The 2.x launcher path can only be verified by this PR's own CI run, which uses the live unpinned runner.

## Follow-up

Once green, rebasing #196–#199 should clear them. Consider pinning `sbt-runner-version` in `ci.yml` so an upstream launcher roll can't silently break CI again.